### PR TITLE
Configure database schema and connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Este fue un proyecto colaborativo. Mi trabajo se centró principalmente en el ba
 - Comentarios y calificaciones disponibles tras una solicitud aceptada.
 - Subida de imágenes y documentación interactiva en Swagger.
 
+## Acceso demo
+
+- Solicitante: `john_doe@example.com`
+- Prestadora: `jane_smith@example.com`
+- Contrasena para ambas: `Demo123!`
+
 ## Ejecutar el backend
 
 1. Entra en la carpeta `retrueque`.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-# s17-11-n-java-next
+# ReTrueque
+
+API REST para una plataforma colaborativa de intercambio de servicios. Permite publicar servicios, solicitar intercambios, gestionar la aceptación de solicitudes y dejar calificaciones una vez completado el acuerdo.
+
+## Mi aporte
+
+Este fue un proyecto colaborativo. Mi trabajo se centró principalmente en el backend: diseño de endpoints y reglas de negocio, autenticación JWT, autorización, flujo de solicitudes, emails transaccionales, carga de imágenes en Amazon S3, migraciones de base de datos y documentación de la API.
+
+## Tecnologías
+
+- Java 17 y Spring Boot 3
+- Spring Security con JWT
+- Spring Data JPA y PostgreSQL
+- Flyway para migraciones
+- Amazon S3 para imágenes
+- Thymeleaf y Resend para emails transaccionales
+- OpenAPI / Swagger
+- Docker
+
+## Funcionalidades destacadas
+
+- Registro, autenticación y verificación de cuentas por correo.
+- Publicación, edición y eliminación de servicios con control de propiedad.
+- Búsqueda paginada y filtros por categoría, provincia y departamento.
+- Solicitudes entre usuarios, con aceptación o rechazo exclusivo del dueño del servicio.
+- Comentarios y calificaciones disponibles tras una solicitud aceptada.
+- Subida de imágenes y documentación interactiva en Swagger.
+
+## Ejecutar el backend
+
+1. Entra en la carpeta `retrueque`.
+2. Copia `example .env` como `.env` y completa las variables con tus credenciales locales.
+3. Crea una base de datos PostgreSQL vacía y ajusta `DATABASE`, `DB_USER` y `DB_PASSWORD`.
+4. Inicia la aplicación en modo desarrollo:
+
+```powershell
+$env:SPRING_PROFILES_ACTIVE="dev"
+.\mvnw.cmd spring-boot:run
+```
+
+Flyway creará el esquema y aplicará las migraciones. En desarrollo Hibernate puede actualizar el esquema; en la configuración base se utiliza `validate`, adecuada para despliegues donde Flyway es la fuente de verdad.
+
+## Documentación de la API
+
+Con la aplicación en ejecución, Swagger UI está disponible en `http://localhost:8080/swagger-ui/index.html`.
+
+Rutas principales:
+
+- `POST /api/v1/auth/register` y `POST /api/v1/auth/login`
+- `GET|POST|PUT|DELETE /api/v1/service`
+- `GET|POST|PUT /api/v1/requests`
+
+## Decisiones técnicas
+
+- Las operaciones de edición y borrado verifican que el recurso pertenezca al usuario autenticado.
+- Las migraciones de Flyway versionan el esquema; por eso producción usa `ddl-auto: validate`.
+- Las URLs del frontend para emails se inyectan por entorno con `FRONTEND_URL`.
+- Las credenciales no se versionan: `.env` está excluido del repositorio y `example .env` contiene solo valores de ejemplo.

--- a/retrueque/Dockerfile
+++ b/retrueque/Dockerfile
@@ -1,11 +1,11 @@
-FROM maven:3.9-eclipse-temurin-17-alpine as build
+FROM maven:3.9-eclipse-temurin-17-alpine AS build
 WORKDIR /app
 COPY pom.xml .
 COPY src ./src
 RUN mvn clean package -DskipTests
 
-# Usa la imagen base de OpenJDK para ejecutar la aplicación
-FROM openjdk:17-jdk-alpine
+# Imagen Java 17 mantenida para ejecutar la aplicacion
+FROM eclipse-temurin:17-jre-alpine
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080

--- a/retrueque/example .env
+++ b/retrueque/example .env
@@ -15,3 +15,5 @@ LINK_CONFIRMATION=http://localhost:3000/auth/verify?token=
 
 JWT_EXPIRATION=86400000
 JWT_SECRETKEY=OuqtXAJaOLVlcEmXSn6h5v2zL+FZgHSVl2ZjjXOXAqY=
+
+CORS_ALLOWED=http://localhost:*

--- a/retrueque/example .env
+++ b/retrueque/example .env
@@ -3,17 +3,19 @@ DB_USER=user
 DB_PASSWORD=password
 
 AWS_REGION=region
-AWS_SECRET_ACCES_KEY=aws+secret+acceskey
+AWS_SECRET_ACCESS_KEY=aws+secret+accesskey
 AWS_BUCKET_NAME=namebucket
 AWS_KEY_ID=awskeyid
 
-EMAIL_PASSWORD=xxxx xxxx xxxx xxxx
 EMAIL_TOKEN_EXPIRATION=900000
-EMAIL_USERNAME=example@gmail.com
+
+RESEND_APIKEY=re_replace_with_your_resend_api_key
+RESEND_EMAIL=ReTrueque <retrueque@your-verified-domain.com>
 
 LINK_CONFIRMATION=http://localhost:3000/auth/verify?token=
 
 JWT_EXPIRATION=86400000
-JWT_SECRETKEY=OuqtXAJaOLVlcEmXSn6h5v2zL+FZgHSVl2ZjjXOXAqY=
+JWT_SECRETKEY=replace-with-a-base64-secret-of-at-least-32-bytes
 
 CORS_ALLOWED=http://localhost:*
+FRONTEND_URL=http://localhost:3000

--- a/retrueque/pom.xml
+++ b/retrueque/pom.xml
@@ -36,10 +36,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
 		<dependency>

--- a/retrueque/src/main/java/com/nocountry/retrueque/config/CorsConfig.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/config/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOriginPatterns(Arrays.stream(corsAllowedOrigins.split(",")).map(String::trim).toList());
     configuration.setAllowedMethods(List.of("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"));
-    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "page"));
     configuration.setAllowCredentials(true);
     configuration.setMaxAge(3600L);
 

--- a/retrueque/src/main/java/com/nocountry/retrueque/config/CorsConfig.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/config/CorsConfig.java
@@ -1,33 +1,32 @@
 package com.nocountry.retrueque.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 public class CorsConfig {
 
+  @Value("${web.cors.allowed-origins}")
+  private String corsAllowedOrigins;
+
   @Bean
-  public WebMvcConfigurer corsCustomConfig(){
-    return new WebMvcConfigurer() {
-      @Override
-      public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins(
-                        "http://localhost:3000",
-                        "http://localhost:3001",
-                        "http://localhost:3002",
-                        "http://localhost:3003",
-                        "http://localhost:3004",
-                        "http://localhost:3005",
-                        "http://localhost:5173",
-                        "https://s17-11-n-java-next-urev.onrender.com/"
-                        )
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true);
-      }
-    };
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOriginPatterns(Arrays.stream(corsAllowedOrigins.split(",")).map(String::trim).toList());
+    configuration.setAllowedMethods(List.of("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"));
+    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+    configuration.setAllowCredentials(true);
+    configuration.setMaxAge(3600L);
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
   }
 }

--- a/retrueque/src/main/java/com/nocountry/retrueque/config/CorsConfig.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/config/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOriginPatterns(Arrays.stream(corsAllowedOrigins.split(",")).map(String::trim).toList());
     configuration.setAllowedMethods(List.of("OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE"));
-    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "page"));
+    configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With", "page","size"));
     configuration.setAllowCredentials(true);
     configuration.setMaxAge(3600L);
 

--- a/retrueque/src/main/java/com/nocountry/retrueque/controller/ServicesController.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/controller/ServicesController.java
@@ -55,8 +55,8 @@ public class ServicesController {
 
   @Operation(summary = "Update service", description = "Update using body and path, only available by authenticated user.")
   @SecurityRequirement(name = "bearer-key")
-  @PutMapping("/{id}")
-  public ResponseEntity<?> updateById(@RequestBody @Valid ServiceReq request, @PathVariable long id){
+  @PutMapping(value = "/{id}", consumes = "multipart/form-data")
+  public ResponseEntity<?> updateById(@ModelAttribute @Valid ServiceReq request, @PathVariable long id){
     var response = this.servicesService.updateById(request, id);
     return ResponseEntity.ok(new ApiResponse<>(response));
   }

--- a/retrueque/src/main/java/com/nocountry/retrueque/exception/EmailDeliveryException.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/exception/EmailDeliveryException.java
@@ -1,0 +1,7 @@
+package com.nocountry.retrueque.exception;
+
+public class EmailDeliveryException extends RuntimeException {
+    public EmailDeliveryException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/retrueque/src/main/java/com/nocountry/retrueque/exception/GlobalExceptionHandler.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/exception/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.mail.MailSendException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -73,13 +72,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, errorResponse.status());
     }
 
-    @ExceptionHandler(MailSendException.class)
-    public ResponseEntity<ErrorResponse> handleMailSendException(MailSendException ex) {
-        // Mensaje genérico para el usuario final
-        //String message = "No se pudo enviar el correo electrónico. Por favor, inténtelo de nuevo más tarde.";
-        // Mensaje genérico para pruebas
-        String message = ex.getMostSpecificCause() != null ? ex.getMostSpecificCause().getMessage() : ex.getMessage();
-        ErrorResponse errorResponse = new ErrorResponse("Error al enviar el correo electrónico: " + message, HttpStatus.SERVICE_UNAVAILABLE);
+    @ExceptionHandler(EmailDeliveryException.class)
+    public ResponseEntity<ErrorResponse> handleEmailDeliveryException(EmailDeliveryException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage(), HttpStatus.SERVICE_UNAVAILABLE);
         return new ResponseEntity<>(errorResponse, errorResponse.status());
     }
 

--- a/retrueque/src/main/java/com/nocountry/retrueque/model/dto/response/RequestRes.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/model/dto/response/RequestRes.java
@@ -9,10 +9,20 @@ public record RequestRes(
         String description,
         LocalDate date,
         Boolean status,
+        Short rating,
+        String review,
         UserRequest user,
-        UserService provider
+        UserService provider,
+        ServiceSummary service
 ) {
+    public record ServiceSummary(
+            Long id,
+            String title
+    ) {
+    }
+
     public record UserService(
+            Long id,
             String name,
             String last_name,
             String img_profile,
@@ -23,6 +33,7 @@ public record RequestRes(
     }
 
     public record UserRequest(
+            Long id,
             String name,
             String last_name,
             String img_profile,

--- a/retrueque/src/main/java/com/nocountry/retrueque/model/entity/Shift.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/model/entity/Shift.java
@@ -16,7 +16,7 @@ public class Shift {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
   private String days;
-  @OneToMany(mappedBy = "shift", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "shift", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<ShiftTimeByShift> shifts;
 
   public Shift(String days) {

--- a/retrueque/src/main/java/com/nocountry/retrueque/model/mapper/RequestMapper.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/model/mapper/RequestMapper.java
@@ -5,14 +5,12 @@ import com.nocountry.retrueque.model.dto.response.CustomPage;
 import com.nocountry.retrueque.model.dto.response.RequestCommentsRes;
 import com.nocountry.retrueque.model.dto.response.RequestRes;
 import com.nocountry.retrueque.model.entity.Request;
-import org.mapstruct.BeforeMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.springframework.data.domain.Page;
 
 @Mapper(componentModel = "spring")
-public interface RequestMapper extends RequestToRequestRes {
+public interface RequestMapper {
     Request toEntity(RequestReq request);
 
     @Mapping(source = "userOrigin.name", target = "name")
@@ -28,31 +26,41 @@ public interface RequestMapper extends RequestToRequestRes {
     @Mapping(target = "pageSize", source = "page.size")
     CustomPage<RequestCommentsRes> toCustomPage(Page<RequestCommentsRes> page);
 
-}
+    default RequestRes toRequestRes(Request request) {
+        var requester = request.getUserOrigin();
+        var requesterProfile = requester.getProfile();
+        var service = request.getServiceTarget();
+        var provider = service.getUser();
+        var providerProfile = provider.getProfile();
 
-@Mapper(componentModel = "spring")
-interface RequestToRequestRes {
-    @BeforeMapping
-    default void beforeToRequestRes(Request request) {
-        if (request.getIsConfirm()) {
-            request.getServiceTarget().getUser().getProfile().setPhone(null);
-        }
+        var requesterData = new RequestRes.UserRequest(
+                requester.getId(),
+                requester.getName(),
+                requester.getLast_name(),
+                requesterProfile.getProfile_image_url(),
+                requesterProfile.getDepartamento().getProvincia().getName(),
+                requesterProfile.getDepartamento().getName()
+        );
+        var providerData = new RequestRes.UserService(
+                provider.getId(),
+                provider.getName(),
+                provider.getLast_name(),
+                providerProfile.getProfile_image_url(),
+                providerProfile.getDepartamento().getProvincia().getName(),
+                providerProfile.getDepartamento().getName(),
+                Boolean.TRUE.equals(request.getIsConfirm()) ? providerProfile.getPhone() : null
+        );
+
+        return new RequestRes(
+                request.getId(),
+                request.getDescription(),
+                request.getDate(),
+                request.getIsConfirm(),
+                request.getRating(),
+                request.getReview(),
+                requesterData,
+                providerData,
+                new RequestRes.ServiceSummary(service.getId(), service.getTitle())
+        );
     }
-
-    @Mappings({
-            @Mapping(source = "userOrigin.name", target = "user.name"),
-            @Mapping(source = "userOrigin.last_name", target = "user.last_name"),
-            @Mapping(source = "userOrigin.profile.profile_image_url", target = "user.img_profile"),
-            @Mapping(source = "userOrigin.profile.departamento.provincia.name", target = "user.provincia"),
-            @Mapping(source = "userOrigin.profile.departamento.name", target = "user.departamento"),
-            @Mapping(source = "isConfirm", target = "status"),
-
-            @Mapping(source = "serviceTarget.user.profile.phone", target = "provider.phone"),
-            @Mapping(source = "serviceTarget.user.name", target = "provider.name"),
-            @Mapping(source = "serviceTarget.user.last_name", target = "provider.last_name"),
-            @Mapping(source = "serviceTarget.user.profile.profile_image_url", target = "provider.img_profile"),
-            @Mapping(source = "serviceTarget.user.profile.departamento.name", target = "provider.departamento"),
-            @Mapping(source = "serviceTarget.user.profile.departamento.provincia.name", target = "provider.provincia")
-    })
-    RequestRes toRequestRes(Request request);
 }

--- a/retrueque/src/main/java/com/nocountry/retrueque/service/EmailServiceImp.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/service/EmailServiceImp.java
@@ -1,5 +1,6 @@
 package com.nocountry.retrueque.service;
 
+import com.nocountry.retrueque.exception.EmailDeliveryException;
 import com.nocountry.retrueque.exception.UserAlreadyVerifiedException;
 import com.nocountry.retrueque.exception.UserEmailNotFoundException;
 import com.nocountry.retrueque.model.dto.request.ResendTokenEmailReq;
@@ -9,15 +10,15 @@ import com.nocountry.retrueque.model.mapper.ResendTokenEmailMapper;
 import com.nocountry.retrueque.repository.UserRepository;
 import com.nocountry.retrueque.service.interfaces.EmailService;
 import com.nocountry.retrueque.service.interfaces.TokenService;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class EmailServiceImp implements EmailService {
 
 
 
-    private final JavaMailSender javaMailSender;
+    private final RestClient.Builder restClientBuilder;
     private final TokenService tokenService;
     private final ResendTokenEmailMapper resendTokenEmailMapper;
     private final UserRepository userRepository;
@@ -37,25 +38,32 @@ public class EmailServiceImp implements EmailService {
     @Value("${email.link.confirmation}")
     private String linkConfirmation;
 
+    @Value("${resend.api-key}")
+    private String resendApiKey;
+
+    @Value("${resend.from}")
+    private String resendFrom;
+
     @Override
     public void sendEmail(String to, String subject, Map<String, Object> templateModel, String templateName) {
+        Context context = new Context();
+        context.setVariables(templateModel);
+        String htmlBody = templateEngine.process(templateName, context);
+
         try {
-            MimeMessage message = javaMailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
-
-            Context context = new Context();
-            context.setVariables(templateModel);
-
-            String htmlBody = templateEngine.process(templateName, context);
-
-            helper.setTo(to);
-            helper.setSubject(subject);
-            helper.setText(htmlBody, true);
-
-            javaMailSender.send(message);
-
-        } catch (MessagingException e) {
-            throw new RuntimeException(e);
+            restClientBuilder
+                    .baseUrl("https://api.resend.com")
+                    .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + resendApiKey)
+                    .defaultHeader(HttpHeaders.USER_AGENT, "retrueque-backend")
+                    .build()
+                    .post()
+                    .uri("/emails")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(new ResendEmailRequest(resendFrom, to, subject, htmlBody))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (RestClientException exception) {
+            throw new EmailDeliveryException("No se pudo enviar el correo en este momento.", exception);
         }
     }
 
@@ -79,8 +87,5 @@ public class EmailServiceImp implements EmailService {
 
         return resendTokenEmailMapper.toResendTokenEmailRes(user.getEmail(), "Verification token has been resent to your email.");
     }
-
-    public void EmailConfirmation(String to, String subject, Map<String, Object> templateModel) {
-
-    }
+    private record ResendEmailRequest(String from, String to, String subject, String html) { }
 }

--- a/retrueque/src/main/java/com/nocountry/retrueque/service/RequestServiceImp.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/service/RequestServiceImp.java
@@ -21,6 +21,7 @@ import com.nocountry.retrueque.service.interfaces.EmailService;
 import com.nocountry.retrueque.service.interfaces.RequestService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,9 @@ public class RequestServiceImp implements RequestService {
     private final ServiceRepository serviceRepository;
     private final EmailService emailService;
     private final AuthService authService;
+
+    @Value("${web.frontend-url}")
+    private String frontendUrl;
 
     @Transactional
     @Override
@@ -63,7 +67,7 @@ public class RequestServiceImp implements RequestService {
         templateModel.put("name", service.getUser().getName()+" "+service.getUser().getLast_name());
         templateModel.put("requesterName", user.getName()+" "+user.getLast_name());
         //debería mostrar el detalle request, pero aún no existe el link, también ponerlo en una variable de entorno
-        templateModel.put("requestUrl","https://s17-11-n-java-next-urev.onrender.com/dashboard/perfil");
+        templateModel.put("requestUrl", frontendUrl + "/dashboard/perfil");
 
         emailService.sendEmail(service.getUser().getEmail(), "¡Has recibido una nueva solicitud de servicio!",templateModel,"request-service");
 
@@ -77,9 +81,8 @@ public class RequestServiceImp implements RequestService {
                 orElseThrow(()-> new RequestNotFoundException("Peticion con ID " + id + " no encontrada."));
 
         String email = this.authService.getAuthUser().getEmail();
-        String a = request.getServiceTarget().getUser().getEmail();
         if (!email.equals(request.getServiceTarget().getUser().getEmail())) {
-            throw new PermissionDeniedException("No tienes permitido aaceptar o cancelar esta solicitud");
+            throw new PermissionDeniedException("No tienes permitido aceptar o cancelar esta solicitud");
         }
 
         request.setIsConfirm(requestUptdateReq.isConfirmed());
@@ -88,7 +91,7 @@ public class RequestServiceImp implements RequestService {
         Map<String, Object> templateModel = new HashMap<>();
         templateModel.put("name", requestSaved.getUserOrigin().getName()+" "+requestSaved.getUserOrigin().getLast_name());
         templateModel.put("providerName", requestSaved.getServiceTarget().getUser().getName()+" "+requestSaved.getServiceTarget().getUser().getLast_name());
-        templateModel.put("requestUrl","https://s17-11-n-java-next-urev.onrender.com/dashboard/perfil");
+        templateModel.put("requestUrl", frontendUrl + "/dashboard/perfil");
 
 
         if(requestUptdateReq.isConfirmed()) {
@@ -97,13 +100,13 @@ public class RequestServiceImp implements RequestService {
                     templateModel, "request-confirmed");
         }
         else {
-            templateModel.put("servicesUrl","https://s17-11-n-java-next-urev.onrender.com");
+            templateModel.put("servicesUrl", frontendUrl);
             emailService.sendEmail(requestSaved.getUserOrigin().getEmail(),
                     "Actualización sobre Tu Solicitud de Servicio",
                     templateModel,"request-rejected");
         }
 
-        String message = requestSaved.getIsConfirm()?"Reques was confirmate":"Reques was rejected";
+        String message = requestSaved.getIsConfirm() ? "Solicitud aceptada" : "Solicitud rechazada";
 
         return new RequestMesRes(requestSaved.getId(),message);
     }

--- a/retrueque/src/main/java/com/nocountry/retrueque/service/ServicesServiceImpl.java
+++ b/retrueque/src/main/java/com/nocountry/retrueque/service/ServicesServiceImpl.java
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mapping.PropertyReferenceException;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -96,24 +97,76 @@ public class ServicesServiceImpl implements ServicesService {
   }
 
   @Override
+  @Transactional
   public ServiceRes updateById(ServiceReq service, long id) {
-    this.verifyIsExist(id);
-    var newService = this.serviceMapper.reqToEntity(service, categoryRepo, s3Service);
-    newService.setUser(this.authService.getAuthUser());
-    var serviceFound = this.serviceRepository.save(newService);
-    return this.serviceMapper.entityToRes(serviceFound);
+    var serviceFound = this.findByIdOrThrow(id);
+    var currentUser = this.authService.getAuthUser();
+    this.verifyOwnership(serviceFound, currentUser);
+
+    serviceFound.setTitle(service.title());
+    serviceFound.setDescription(service.description());
+    serviceFound.setRules(service.rules());
+    serviceFound.setCategory(this.serviceMapper.map(service.categoryId(), categoryRepo));
+    serviceFound.setDepartamento(currentUser.getProfile().getDepartamento());
+
+    if (service.imgUrl() != null && !service.imgUrl().isEmpty()) {
+      serviceFound.setImgUrl(service.imgUrl().stream()
+              .map(s3Service::uploadFile)
+              .collect(Collectors.joining(",")));
+    }
+
+    this.updateShift(serviceFound, service);
+    return this.serviceMapper.entityToRes(this.serviceRepository.save(serviceFound));
   }
 
   @Override
+  @Transactional
   public String deleteById(long id) {
-    this.verifyIsExist(id);
-    this.serviceRepository.deleteById(id);
+    var serviceFound = this.findByIdOrThrow(id);
+    this.verifyOwnership(serviceFound, this.authService.getAuthUser());
+    this.serviceRepository.delete(serviceFound);
     return "Service deleted, id: " + id;
   }
 
-  private void verifyIsExist(long id) {
-    boolean isExist = this.serviceRepository.existsById(id);
-    if (!isExist) throw new ServicesNotFoundException(id);
+  private Services findByIdOrThrow(long id) {
+    return this.serviceRepository.findById(id)
+            .orElseThrow(() -> new ServicesNotFoundException(id));
+  }
+
+  private void verifyOwnership(Services service, com.nocountry.retrueque.model.entity.UserEntity currentUser) {
+    if (!service.getUser().getId().equals(currentUser.getId())) {
+      throw new com.nocountry.retrueque.exception.PermissionDeniedException(
+              "No tienes permiso para modificar este servicio");
+    }
+  }
+
+  private void updateShift(Services service, ServiceReq request) {
+    var shift = service.getShift();
+    if (shift == null) {
+      shift = new com.nocountry.retrueque.model.entity.Shift();
+      service.setShift(shift);
+    }
+    var serviceShift = shift;
+
+    serviceShift.setDays(request.days().stream()
+            .map(day -> com.nocountry.retrueque.model.enums.Day.fromId(day).name())
+            .sorted()
+            .collect(Collectors.joining("-")));
+
+    var shiftTimes = request.shiftTime().stream()
+            .map(id -> {
+              var shiftTime = new ShiftTimeByShift();
+              shiftTime.setShiftTime(ShiftTime.fromId(id));
+              shiftTime.setShift(serviceShift);
+              return shiftTime;
+            })
+            .collect(Collectors.toCollection(ArrayList::new));
+    if (serviceShift.getShifts() == null) {
+      serviceShift.setShifts(new ArrayList<>());
+    } else {
+      serviceShift.getShifts().clear();
+    }
+    serviceShift.getShifts().addAll(shiftTimes);
   }
 
   private void isValidUser(UserProfileEntity profile) {

--- a/retrueque/src/main/resources/application-dev.yml
+++ b/retrueque/src/main/resources/application-dev.yml
@@ -1,0 +1,9 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+logging:
+  level:
+    org.springframework.security: DEBUG

--- a/retrueque/src/main/resources/application.yml
+++ b/retrueque/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+    properties:
+      hibernate:
+        default_schema: retrueque
   mail:
     host: smtp.gmail.com
     port: 587
@@ -26,6 +29,10 @@ spring:
           auth: true
           starttls:
             enable: true
+  flyway:
+    schemas: retrueque
+    default-schema: retrueque
+    create-schemas: true
 logging:
   level:
     org.springframework.security: DEBUG
@@ -48,5 +55,5 @@ aws:
   s3:
     bucketName: ${AWS_BUCKET_NAME}
     accessKeyId: ${AWS_KEY_ID}
-    secretAccessKey: ${AWS_SECRET_ACCES_KEY}
+    secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
     region: ${AWS_REGION}

--- a/retrueque/src/main/resources/application.yml
+++ b/retrueque/src/main/resources/application.yml
@@ -57,3 +57,6 @@ aws:
     accessKeyId: ${AWS_KEY_ID}
     secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
     region: ${AWS_REGION}
+web:
+  cors:
+    allowed-origins: ${CORS_ALLOWED}

--- a/retrueque/src/main/resources/application.yml
+++ b/retrueque/src/main/resources/application.yml
@@ -11,6 +11,13 @@ spring:
     url: ${DATABASE}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
+    hikari:
+      schema: retrueque
+      maximum-pool-size: ${DB_POOL_MAX_SIZE:2}
+      minimum-idle: ${DB_POOL_MIN_IDLE:0}
+      connection-timeout: ${DB_POOL_CONNECTION_TIMEOUT_MS:30000}
+      idle-timeout: ${DB_POOL_IDLE_TIMEOUT_MS:300000}
+      pool-name: ${spring.application.name}-pool
   jpa:
     hibernate:
       ddl-auto: validate

--- a/retrueque/src/main/resources/application.yml
+++ b/retrueque/src/main/resources/application.yml
@@ -13,31 +13,18 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: validate
+    show-sql: false
     properties:
       hibernate:
         default_schema: retrueque
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${EMAIL_USERNAME}
-    password: ${EMAIL_PASSWORD}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
   flyway:
     schemas: retrueque
     default-schema: retrueque
     create-schemas: true
 logging:
   level:
-    org.springframework.security: DEBUG
-    org.springframework.security.web.authentication: DEBUG
-    org.springframework.security.web.access: DEBUG
+    org.springframework.security: INFO
 jwt:
   time:
     expiration: ${JWT_EXPIRATION}
@@ -51,6 +38,9 @@ email:
       expiration: ${EMAIL_TOKEN_EXPIRATION}
   link:
     confirmation: ${LINK_CONFIRMATION}
+resend:
+  api-key: ${RESEND_APIKEY}
+  from: ${RESEND_EMAIL}
 aws:
   s3:
     bucketName: ${AWS_BUCKET_NAME}
@@ -58,5 +48,6 @@ aws:
     secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
     region: ${AWS_REGION}
 web:
+  frontend-url: ${FRONTEND_URL}
   cors:
     allowed-origins: ${CORS_ALLOWED}

--- a/retrueque/src/main/resources/application.yml
+++ b/retrueque/src/main/resources/application.yml
@@ -48,6 +48,6 @@ aws:
     secretAccessKey: ${AWS_SECRET_ACCESS_KEY}
     region: ${AWS_REGION}
 web:
-  frontend-url: ${FRONTEND_URL}
+  frontend-url: ${FRONTEND_URL:http://localhost:3000}
   cors:
-    allowed-origins: ${CORS_ALLOWED}
+    allowed-origins: ${CORS_ALLOWED:${FRONTEND_URL:http://localhost:3000}}

--- a/retrueque/src/main/resources/db/migration/V16__Align_id_columns_with_jpa_long.sql
+++ b/retrueque/src/main/resources/db/migration/V16__Align_id_columns_with_jpa_long.sql
@@ -1,0 +1,102 @@
+ALTER TABLE IF EXISTS departamentos DROP CONSTRAINT IF EXISTS departamentos_provincia_id_fkey;
+ALTER TABLE IF EXISTS users DROP CONSTRAINT IF EXISTS users_role_id_fkey;
+ALTER TABLE IF EXISTS user_profiles DROP CONSTRAINT IF EXISTS user_profiles_departamento_id_fkey;
+ALTER TABLE IF EXISTS user_profiles DROP CONSTRAINT IF EXISTS user_profiles_user_id_fkey;
+ALTER TABLE IF EXISTS shift_time_by_shift DROP CONSTRAINT IF EXISTS shift_time_by_shift_shift_id_fkey;
+ALTER TABLE IF EXISTS services DROP CONSTRAINT IF EXISTS services_user_id_fkey;
+ALTER TABLE IF EXISTS services DROP CONSTRAINT IF EXISTS services_category_id_fkey;
+ALTER TABLE IF EXISTS services DROP CONSTRAINT IF EXISTS services_departamento_id_fkey;
+ALTER TABLE IF EXISTS services DROP CONSTRAINT IF EXISTS services_shift_id_fkey;
+ALTER TABLE IF EXISTS requests DROP CONSTRAINT IF EXISTS requests_user_origin_id_fkey;
+ALTER TABLE IF EXISTS requests DROP CONSTRAINT IF EXISTS requests_service_target_id_fkey;
+ALTER TABLE IF EXISTS report DROP CONSTRAINT IF EXISTS report_user_id_fkey;
+ALTER TABLE IF EXISTS report DROP CONSTRAINT IF EXISTS report_service_id_fkey;
+
+ALTER TABLE roles ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE provincias ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE departamentos ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE departamentos ALTER COLUMN provincia_id TYPE BIGINT;
+ALTER TABLE category ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE users ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE user_profiles ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE shift ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE shift_time_by_shift ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE services ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE requests ALTER COLUMN id TYPE BIGINT;
+ALTER TABLE report ALTER COLUMN id TYPE BIGINT;
+
+ALTER SEQUENCE IF EXISTS roles_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS provincias_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS departamentos_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS category_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS users_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS user_profiles_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS shift_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS shift_time_by_shift_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS services_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS requests_id_seq AS BIGINT;
+ALTER SEQUENCE IF EXISTS report_id_seq AS BIGINT;
+
+ALTER TABLE departamentos
+    ADD CONSTRAINT departamentos_provincia_id_fkey
+    FOREIGN KEY (provincia_id) REFERENCES provincias(id);
+
+ALTER TABLE users
+    ADD CONSTRAINT users_role_id_fkey
+    FOREIGN KEY (role_id) REFERENCES roles(id);
+
+ALTER TABLE user_profiles
+    ADD CONSTRAINT user_profiles_departamento_id_fkey
+    FOREIGN KEY (departamento_id) REFERENCES departamentos(id);
+
+ALTER TABLE user_profiles
+    ADD CONSTRAINT user_profiles_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE shift_time_by_shift
+    ADD CONSTRAINT shift_time_by_shift_shift_id_fkey
+    FOREIGN KEY (shift_id) REFERENCES shift(id) ON DELETE CASCADE;
+
+ALTER TABLE services
+    ADD CONSTRAINT services_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id);
+
+ALTER TABLE services
+    ADD CONSTRAINT services_category_id_fkey
+    FOREIGN KEY (category_id) REFERENCES category(id);
+
+ALTER TABLE services
+    ADD CONSTRAINT services_departamento_id_fkey
+    FOREIGN KEY (departamento_id) REFERENCES departamentos(id);
+
+ALTER TABLE services
+    ADD CONSTRAINT services_shift_id_fkey
+    FOREIGN KEY (shift_id) REFERENCES shift(id);
+
+ALTER TABLE requests
+    ADD CONSTRAINT requests_user_origin_id_fkey
+    FOREIGN KEY (user_origin_id) REFERENCES users(id) ON DELETE CASCADE;
+
+ALTER TABLE requests
+    ADD CONSTRAINT requests_service_target_id_fkey
+    FOREIGN KEY (service_target_id) REFERENCES services(id) ON DELETE CASCADE;
+
+ALTER TABLE report
+    ADD CONSTRAINT report_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL;
+
+ALTER TABLE report
+    ADD CONSTRAINT report_service_id_fkey
+    FOREIGN KEY (service_id) REFERENCES services(id) ON DELETE SET NULL;
+
+SELECT setval('roles_id_seq', COALESCE((SELECT MAX(id) FROM roles), 1), true);
+SELECT setval('provincias_id_seq', COALESCE((SELECT MAX(id) FROM provincias), 1), true);
+SELECT setval('departamentos_id_seq', COALESCE((SELECT MAX(id) FROM departamentos), 1), true);
+SELECT setval('category_id_seq', COALESCE((SELECT MAX(id) FROM category), 1), true);
+SELECT setval('users_id_seq', COALESCE((SELECT MAX(id) FROM users), 1), true);
+SELECT setval('user_profiles_id_seq', COALESCE((SELECT MAX(id) FROM user_profiles), 1), true);
+SELECT setval('shift_id_seq', COALESCE((SELECT MAX(id) FROM shift), 1), true);
+SELECT setval('shift_time_by_shift_id_seq', COALESCE((SELECT MAX(id) FROM shift_time_by_shift), 1), true);
+SELECT setval('services_id_seq', COALESCE((SELECT MAX(id) FROM services), 1), true);
+SELECT setval('requests_id_seq', COALESCE((SELECT MAX(id) FROM requests), 1), true);
+SELECT setval('report_id_seq', COALESCE((SELECT MAX(id) FROM report), 1), true);

--- a/retrueque/src/main/resources/db/migration/V17__Configure_portfolio_demo.sql
+++ b/retrueque/src/main/resources/db/migration/V17__Configure_portfolio_demo.sql
@@ -1,0 +1,15 @@
+UPDATE users
+SET password = '$2a$10$F8NgTjUepWPZURo1FLAwO.sBHlgbr9GFh0z3NrFLNeYEKcObOAdeC',
+    is_enabled = TRUE,
+    is_deleted = FALSE
+WHERE email IN ('john_doe@example.com', 'jane_smith@example.com');
+
+UPDATE requests
+SET date = CURRENT_DATE - ((2036 - id)::INTEGER)
+WHERE id BETWEEN 2002 AND 2036;
+
+UPDATE requests
+SET is_confirm = FALSE,
+    rating = NULL,
+    review = NULL
+WHERE id BETWEEN 2030 AND 2036;

--- a/retrueque/src/main/resources/db/migration/V18__Create_demo_exchange_flow.sql
+++ b/retrueque/src/main/resources/db/migration/V18__Create_demo_exchange_flow.sql
@@ -1,0 +1,47 @@
+INSERT INTO requests (
+    date,
+    description,
+    is_confirm,
+    rating,
+    review,
+    service_target_id,
+    user_origin_id
+)
+SELECT
+    CURRENT_DATE,
+    'Hola Jane, me interesa intercambiar una reparacion de paredes por una lectura astral.',
+    NULL,
+    NULL,
+    NULL,
+    2002,
+    2002
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM requests
+    WHERE service_target_id = 2002
+      AND user_origin_id = 2002
+);
+
+INSERT INTO requests (
+    date,
+    description,
+    is_confirm,
+    rating,
+    review,
+    service_target_id,
+    user_origin_id
+)
+SELECT
+    CURRENT_DATE - 2,
+    'Hola John, quisiera solicitar tu servicio de reparacion de paredes.',
+    TRUE,
+    5,
+    'Excelente intercambio. John fue puntual, claro y muy cuidadoso con el trabajo.',
+    2001,
+    2003
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM requests
+    WHERE service_target_id = 2001
+      AND user_origin_id = 2003
+);

--- a/retrueque/src/test/java/com/nocountry/retrueque/model/mapper/RequestMapperTest.java
+++ b/retrueque/src/test/java/com/nocountry/retrueque/model/mapper/RequestMapperTest.java
@@ -1,0 +1,87 @@
+package com.nocountry.retrueque.model.mapper;
+
+import com.nocountry.retrueque.model.entity.DepartamentoEntity;
+import com.nocountry.retrueque.model.entity.ProvinciaEntity;
+import com.nocountry.retrueque.model.entity.Request;
+import com.nocountry.retrueque.model.entity.Services;
+import com.nocountry.retrueque.model.entity.UserEntity;
+import com.nocountry.retrueque.model.entity.UserProfileEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestMapperTest {
+    private final RequestMapper mapper = Mappers.getMapper(RequestMapper.class);
+    private Request request;
+
+    @BeforeEach
+    void setUp() {
+        request = mock(Request.class);
+        Services service = mock(Services.class);
+        UserEntity requester = mock(UserEntity.class);
+        UserEntity provider = mock(UserEntity.class);
+        UserProfileEntity requesterProfile = mock(UserProfileEntity.class);
+        UserProfileEntity providerProfile = mock(UserProfileEntity.class);
+        DepartamentoEntity requesterDepartment = mock(DepartamentoEntity.class);
+        DepartamentoEntity providerDepartment = mock(DepartamentoEntity.class);
+        ProvinciaEntity requesterProvince = mock(ProvinciaEntity.class);
+        ProvinciaEntity providerProvince = mock(ProvinciaEntity.class);
+
+        when(request.getId()).thenReturn(41L);
+        when(request.getDescription()).thenReturn("Quiero intercambiar servicios");
+        when(request.getDate()).thenReturn(LocalDate.of(2026, 7, 21));
+        when(request.getUserOrigin()).thenReturn(requester);
+        when(request.getServiceTarget()).thenReturn(service);
+        when(service.getId()).thenReturn(2001L);
+        when(service.getTitle()).thenReturn("Reparacion de paredes");
+        when(service.getUser()).thenReturn(provider);
+
+        when(requester.getId()).thenReturn(2002L);
+        when(requester.getName()).thenReturn("John");
+        when(requester.getLast_name()).thenReturn("Doe");
+        when(requester.getProfile()).thenReturn(requesterProfile);
+        when(requesterProfile.getDepartamento()).thenReturn(requesterDepartment);
+        when(requesterDepartment.getProvincia()).thenReturn(requesterProvince);
+        when(requesterDepartment.getName()).thenReturn("Capital");
+        when(requesterProvince.getName()).thenReturn("Mendoza");
+
+        when(provider.getId()).thenReturn(2003L);
+        when(provider.getName()).thenReturn("Jane");
+        when(provider.getLast_name()).thenReturn("Smith");
+        when(provider.getProfile()).thenReturn(providerProfile);
+        when(providerProfile.getDepartamento()).thenReturn(providerDepartment);
+        when(providerProfile.getPhone()).thenReturn("+54 9 11 3456 7890");
+        when(providerDepartment.getProvincia()).thenReturn(providerProvince);
+        when(providerDepartment.getName()).thenReturn("Capital");
+        when(providerProvince.getName()).thenReturn("Mendoza");
+    }
+
+    @Test
+    void pendingRequestHidesProviderPhoneAndIncludesService() {
+        when(request.getIsConfirm()).thenReturn(null);
+
+        var response = mapper.toRequestRes(request);
+
+        assertNull(response.provider().phone());
+        assertEquals(2001L, response.service().id());
+        assertEquals("Reparacion de paredes", response.service().title());
+        assertEquals(2002L, response.user().id());
+        assertEquals(2003L, response.provider().id());
+    }
+
+    @Test
+    void confirmedRequestIncludesProviderPhone() {
+        when(request.getIsConfirm()).thenReturn(true);
+
+        var response = mapper.toRequestRes(request);
+
+        assertEquals("+54 9 11 3456 7890", response.provider().phone());
+    }
+}

--- a/retrueque/src/test/java/com/nocountry/retrueque/service/ServicesServiceImplTest.java
+++ b/retrueque/src/test/java/com/nocountry/retrueque/service/ServicesServiceImplTest.java
@@ -1,0 +1,109 @@
+package com.nocountry.retrueque.service;
+
+import com.nocountry.retrueque.exception.PermissionDeniedException;
+import com.nocountry.retrueque.model.dto.request.ServiceReq;
+import com.nocountry.retrueque.model.dto.response.ServiceRes;
+import com.nocountry.retrueque.model.entity.Category;
+import com.nocountry.retrueque.model.entity.DepartamentoEntity;
+import com.nocountry.retrueque.model.entity.Services;
+import com.nocountry.retrueque.model.entity.UserEntity;
+import com.nocountry.retrueque.model.entity.UserProfileEntity;
+import com.nocountry.retrueque.model.mapper.PageMapper;
+import com.nocountry.retrueque.model.mapper.ServiceMapper;
+import com.nocountry.retrueque.repository.CategoryRepository;
+import com.nocountry.retrueque.repository.DepartamentoRepository;
+import com.nocountry.retrueque.repository.ServiceRepository;
+import com.nocountry.retrueque.service.interfaces.AuthService;
+import com.nocountry.retrueque.service.interfaces.S3FileUploadService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ServicesServiceImplTest {
+
+    @Mock private ServiceRepository serviceRepository;
+    @Mock private DepartamentoRepository departamentoRepository;
+    @Mock private CategoryRepository categoryRepository;
+    @Mock private ServiceMapper serviceMapper;
+    @Mock private PageMapper pageMapper;
+    @Mock private AuthService authService;
+    @Mock private S3FileUploadService s3FileUploadService;
+
+    @InjectMocks private ServicesServiceImpl servicesService;
+
+    private final ServiceReq request = new ServiceReq(
+            "Clases de guitarra", "Clases para principiantes", "Llegar puntualmente", null,
+            1, Set.of(1, 3), Set.of(1, 2));
+
+    private Services service;
+    private UserEntity owner;
+
+    @BeforeEach
+    void setUp() {
+        owner = user(1L);
+        service = new Services();
+        service.setId(10L);
+        service.setUser(owner);
+    }
+
+    @Test
+    void updateRejectsAUserWhoDoesNotOwnTheService() {
+        when(serviceRepository.findById(10L)).thenReturn(Optional.of(service));
+        when(authService.getAuthUser()).thenReturn(user(2L));
+
+        assertThrows(PermissionDeniedException.class,
+                () -> servicesService.updateById(request, 10L));
+
+        verify(serviceRepository, never()).save(any());
+    }
+
+    @Test
+    void deleteRejectsAUserWhoDoesNotOwnTheService() {
+        when(serviceRepository.findById(10L)).thenReturn(Optional.of(service));
+        when(authService.getAuthUser()).thenReturn(user(2L));
+
+        assertThrows(PermissionDeniedException.class,
+                () -> servicesService.deleteById(10L));
+
+        verify(serviceRepository, never()).delete((Services) any());
+    }
+
+    @Test
+    void updateSavesTheExistingService() {
+        Category category = new Category();
+        UserEntity authenticatedOwner = user(1L);
+        ServiceRes response = org.mockito.Mockito.mock(ServiceRes.class);
+
+        when(serviceRepository.findById(10L)).thenReturn(Optional.of(service));
+        when(authService.getAuthUser()).thenReturn(authenticatedOwner);
+        when(serviceMapper.map(1, categoryRepository)).thenReturn(category);
+        when(serviceRepository.save(service)).thenReturn(service);
+        when(serviceMapper.entityToRes(service)).thenReturn(response);
+
+        servicesService.updateById(request, 10L);
+
+        verify(serviceRepository).save(service);
+    }
+
+    private UserEntity user(Long id) {
+        UserEntity user = new UserEntity();
+        user.setId(id);
+        UserProfileEntity profile = new UserProfileEntity();
+        profile.setDepartamento(new DepartamentoEntity());
+        user.setProfile(profile);
+        return user;
+    }
+}


### PR DESCRIPTION
## Summary

- set `retrueque` as the default schema for Hikari connections
- limit the Hikari pool to two connections by default
- expose pool sizing and timeout overrides through environment variables

## Why

Keep this portfolio service isolated in its own Supabase schema while limiting its share of the database connection budget.

## Validation

- `./mvnw -q -DskipTests package`
- service unit tests pass; the application-context test requires a valid external `DATABASE` JDBC URL